### PR TITLE
Update to support pubKeyHash and scriptHash for zcash forks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+registry=https://registry.npmjs.org/
+always-auth=true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@bitgo-forks/ecpair",
-  "version": "0.0.0-semantic-release-managed",
-  "description": "Fork of ecpair with BitGo specific changes",
+  "name": "@runonflux/bitgo-ecpair",
+  "version": "1.0.1",
+  "description": "Fork of ecpair with BitGo and Zelcore specific changes",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "engines": {

--- a/src/types.js
+++ b/src/types.js
@@ -18,8 +18,8 @@ exports.Network = exports.typeforce.compile({
     public: exports.typeforce.UInt32,
     private: exports.typeforce.UInt32,
   },
-  pubKeyHash: exports.typeforce.UInt8,
-  scriptHash: exports.typeforce.UInt8,
+  pubKeyHash: exports.typeforce.UInt16,
+  scriptHash: exports.typeforce.UInt16,
   wif: exports.typeforce.UInt8,
 });
 exports.Buffer256bit = exports.typeforce.BufferN(32);

--- a/ts_src/types.ts
+++ b/ts_src/types.ts
@@ -7,8 +7,8 @@ export const Network = typeforce.compile({
     public: typeforce.UInt32,
     private: typeforce.UInt32,
   },
-  pubKeyHash: typeforce.UInt8,
-  scriptHash: typeforce.UInt8,
+  pubKeyHash: typeforce.UInt16,
+  scriptHash: typeforce.UInt16,
   wif: typeforce.UInt8,
 });
 


### PR DESCRIPTION
Description
When creating Zcash ECPAIR from WIF and passing network options, a typeforce check will fail.

Reason
Because Zcash and some forks based on it have pubKeyHash and scriptHash bigger than UInt8

These two values don't appear to be used in this library.